### PR TITLE
Updated Dependencies

### DIFF
--- a/migrations/20210701694200_alter_dependencies.sql
+++ b/migrations/20210701694200_alter_dependencies.sql
@@ -1,6 +1,7 @@
 ALTER TABLE dependencies
 -- drop and add to clear the now obsolete version IDs?
 -- previously referenced versions instead of mods
+ALTER COLUMN id TYPE bigint,
 DROP COLUMN dependent_id,
 ADD COLUMN dependent_id bigint REFERENCES mods ON UPDATE CASCADE NOT NULL,
 DROP COLUMN dependency_id,

--- a/migrations/20210701694200_alter_dependencies.sql
+++ b/migrations/20210701694200_alter_dependencies.sql
@@ -1,0 +1,9 @@
+ALTER TABLE dependencies
+-- drop and add to clear the now obsolete version IDs?
+-- previously referenced versions instead of mods
+DROP COLUMN dependent_id,
+ADD COLUMN dependent_id bigint REFERENCES mods ON UPDATE CASCADE NOT NULL,
+DROP COLUMN dependency_id,
+ADD COLUMN dependency_id bigint REFERENCES mods ON UPDATE CASCADE NOT NULL,
+ADD COLUMN version_id bigint REFERENCES versions,
+ADD COLUMN min_version_num varchar(32)

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -168,7 +168,6 @@ pub struct NotificationId(pub i64);
 pub struct NotificationActionId(pub i32);
 
 use crate::models::ids;
-
 impl From<ids::ModId> for ModId {
     fn from(id: ids::ModId) -> Self {
         ModId(id.0 as i64)

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -93,13 +93,19 @@ generate_ids!(
     "SELECT EXISTS(SELECT 1 FROM reports WHERE id=$1)",
     ReportId
 );
-
 generate_ids!(
     pub generate_notification_id,
     NotificationId,
     8,
     "SELECT EXISTS(SELECT 1 FROM notifications WHERE id=$1)",
     NotificationId
+);
+generate_ids!(
+    pub generate_dependency_id,
+    DependencyId,
+    8,
+    "SELECT EXISTS(SELECT 1 FROM dependencies WHERE id=$1)",
+    DependencyId
 );
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Type)]
@@ -167,6 +173,10 @@ pub struct NotificationId(pub i64);
 #[sqlx(transparent)]
 pub struct NotificationActionId(pub i32);
 
+#[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
+pub struct DependencyId(pub i64);
+
 use crate::models::ids;
 impl From<ids::ModId> for ModId {
     fn from(id: ids::ModId) -> Self {
@@ -226,5 +236,15 @@ impl From<ids::NotificationId> for NotificationId {
 impl From<NotificationId> for ids::NotificationId {
     fn from(id: NotificationId) -> Self {
         ids::NotificationId(id.0 as u64)
+    }
+}
+impl From<ids::DependencyId> for DependencyId {
+    fn from(id: ids::DependencyId) -> Self {
+        DependencyId(id.0 as i64)
+    }
+}
+impl From<DependencyId> for ids::DependencyId {
+    fn from(id: DependencyId) -> Self {
+        ids::DependencyId(id.0 as u64)
     }
 }

--- a/src/database/models/mod_item.rs
+++ b/src/database/models/mod_item.rs
@@ -1,4 +1,6 @@
 use super::ids::*;
+use crate::models::mods::Dependency;
+use sqlx::{Transaction, Postgres};
 
 #[derive(Debug)]
 pub struct DonationUrl {
@@ -51,6 +53,7 @@ pub struct ModBuilder {
     pub is_nsfw: bool,
     pub slug: String,
     pub donation_urls: Vec<DonationUrl>,
+    pub dependencies: Option<Vec<Dependency>>,
 }
 
 impl ModBuilder {
@@ -78,7 +81,7 @@ impl ModBuilder {
             discord_url: self.discord_url,
             slug: Some(self.slug),
         };
-        mod_struct.insert(&mut *transaction).await?;
+        mod_struct.insert(&mut *transaction).await?; // inserts all of the above values into the DB
 
         for mut version in self.initial_versions {
             version.mod_id = self.mod_id;
@@ -101,6 +104,25 @@ impl ModBuilder {
             )
             .execute(&mut *transaction)
             .await?;
+        }
+
+        if let Some(deps) = self.dependencies {
+            for dependency in deps {
+                let dependency_id = generate_dependency_id(&mut *transaction).await?;
+                sqlx::query!(
+                    "
+                    INSERT INTO dependencies (id, dependency_type, dependent_id, dependency_id, version_id)
+                    VALUES ($1, $2, $3, $4, $5)
+                    ",
+                    dependency_id.0 as i32,
+                    dependency.dependency_type.as_str(),
+                    self.mod_id as ModId,
+                    dependency.mod_id.0 as i64,
+                    0, // i think we agreed to remove this?
+                )
+                .execute(&mut *transaction)
+                .await?;
+            }
         }
 
         Ok(self.mod_id)
@@ -162,7 +184,7 @@ impl Mod {
             self.status.0,
             self.discord_url.as_ref(),
             self.slug.as_ref(),
-            self.is_nsfw
+            self.is_nsfw,
         )
         .execute(&mut *transaction)
         .await?;
@@ -382,6 +404,16 @@ impl Mod {
         .execute(exec)
         .await?;
 
+        sqlx::query!(
+            "
+            DELETE FROM dependencies
+            WHERE dependent_id = $1 OR dependency_id = $1
+            ",
+            id as ModId,
+        )
+        .execute(exec)
+        .await?;
+
         Ok(Some(()))
     }
 
@@ -424,22 +456,24 @@ impl Mod {
             m.issues_url issues_url, m.source_url source_url, m.wiki_url wiki_url, m.discord_url discord_url,
             m.team_id team_id, m.slug slug,
             s.status status_name,
-            STRING_AGG(DISTINCT c.category, ',') categories, STRING_AGG(DISTINCT v.id::text, ',') versions
+            STRING_AGG(DISTINCT c.category, ',') categories, STRING_AGG(DISTINCT v.id::text, ',') versions,
+            STRING_AGG(DISTINCT d.dependent_id::text, ',') dependencies
             FROM mods m
             LEFT OUTER JOIN mods_categories mc ON joining_mod_id = m.id
             LEFT OUTER JOIN categories c ON mc.joining_category_id = c.id
             LEFT OUTER JOIN versions v ON v.mod_id = m.id
+            LEFT OUTER JOIN dependencies d ON d.dependent_id = m.id
             INNER JOIN statuses s ON s.id = m.status
             WHERE m.id = $1
             GROUP BY m.id, s.id;
             ",
             id as ModId,
         )
-            .fetch_optional(executor)
-            .await?;
+        .fetch_optional(executor)
+        .await?;
 
         if let Some(m) = result {
-            Ok(Some(QueryMod {
+            Ok(Some(QueryMod { // maybe refactor this? duplicated on line 556
                 inner: Mod {
                     id: ModId(m.id),
                     team_id: TeamId(m.team_id),
@@ -473,6 +507,7 @@ impl Mod {
                     .map(|x| VersionId(x.parse().unwrap_or_default()))
                     .collect(),
                 donation_urls: vec![],
+                dependencies: m.dependencies.unwrap_or_default().split(',').map(|x| x.to_string()).collect(),
                 status: crate::models::mods::ModStatus::from_str(&m.status_name),
             }))
         } else {
@@ -498,11 +533,13 @@ impl Mod {
             m.issues_url issues_url, m.source_url source_url, m.wiki_url wiki_url, m.discord_url discord_url,
             m.team_id team_id, m.slug slug,
             s.status status_name,
-            STRING_AGG(DISTINCT c.category, ',') categories, STRING_AGG(DISTINCT v.id::text, ',') versions
+            STRING_AGG(DISTINCT c.category, ',') categories, STRING_AGG(DISTINCT v.id::text, ',') versions,
+            STRING_AGG(DISTINCT d.dependent_id::text, ',') dependencies
             FROM mods m
             LEFT OUTER JOIN mods_categories mc ON joining_mod_id = m.id
             LEFT OUTER JOIN categories c ON mc.joining_category_id = c.id
             LEFT OUTER JOIN versions v ON v.mod_id = m.id
+            LEFT OUTER JOIN dependencies d ON d.dependent_id = m.id
             INNER JOIN statuses s ON s.id = m.status
             WHERE m.id IN (SELECT * FROM UNNEST($1::bigint[]))
             GROUP BY m.id, s.id;
@@ -511,7 +548,7 @@ impl Mod {
         )
             .fetch_many(exec)
             .try_filter_map(|e| async {
-                Ok(e.right().map(|m| QueryMod {
+                Ok(e.right().map(|m| QueryMod { // maybe refactor this? duplicated on line 475
                     inner: Mod {
                         id: ModId(m.id),
                         team_id: TeamId(m.team_id),
@@ -530,11 +567,12 @@ impl Mod {
                         is_nsfw: m.is_nsfw,
                         slug: m.slug.clone(),
                         body: m.body.clone(),
-                        follows: m.follows
+                        follows: m.follows,
                     },
                     categories: m.categories.unwrap_or_default().split(',').map(|x| x.to_string()).collect(),
                     versions: m.versions.unwrap_or_default().split(',').map(|x| VersionId(x.parse().unwrap_or_default())).collect(),
                     donation_urls: vec![],
+                    dependencies: m.dependencies.unwrap_or_default().split(',').map(|x| x.to_string()).collect(),
                     status: crate::models::mods::ModStatus::from_str(&m.status_name),
                 }))
             })
@@ -549,5 +587,6 @@ pub struct QueryMod {
     pub categories: Vec<String>,
     pub versions: Vec<VersionId>,
     pub donation_urls: Vec<DonationUrl>,
+    pub dependencies: Vec<String>, // Returns a list of mod ids for all of its dependencies
     pub status: crate::models::mods::ModStatus,
 }

--- a/src/models/ids.rs
+++ b/src/models/ids.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-pub use super::mods::{ModId, VersionId};
+pub use super::mods::{ModId, VersionId, DependencyId};
 pub use super::notifications::NotificationId;
 pub use super::reports::ReportId;
 pub use super::teams::TeamId;
@@ -111,6 +111,7 @@ base62_id_impl!(VersionId, VersionId);
 base62_id_impl!(TeamId, TeamId);
 base62_id_impl!(ReportId, ReportId);
 base62_id_impl!(NotificationId, NotificationId);
+base62_id_impl!(DependencyId, DependencyId);
 
 pub mod base62_impl {
     use serde::de::{self, Deserializer, Visitor};

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -165,7 +165,6 @@ pub struct Version {
     pub files: Vec<VersionFile>,
     /// A list of mods that this version depends on.
     pub dependencies: Vec<Dependency>,
-
 }
 
 /// A single mod file, with a url for the file and the file's hash
@@ -182,14 +181,16 @@ pub struct VersionFile {
     pub primary: bool,
 }
 
-/// A dependency which describes what versions are required, break support, or are optional to the
-/// version's functionality
+/// A dependency is another mod is either `Required`, `Optional`, or `Incompatible` (breaks usage)
+/// to the mod's functionality
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Dependency {
     /// The filename of the file.
-    pub version_id: VersionId,
+    pub mod_id: ModId,
     /// Whether the file is the primary file of a version
     pub dependency_type: DependencyType,
+    /// Optional minimum version number
+    pub min_version_num: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -63,6 +63,8 @@ pub struct Mod {
     pub discord_url: Option<String>,
     /// An optional list of all donation links the mod has
     pub donation_urls: Option<Vec<DonationLink>>,
+    /// A list of dependencies
+    pub dependencies: Option<Vec<Dependency>>,
 }
 
 
@@ -192,6 +194,11 @@ pub struct Dependency {
     /// Optional minimum version number
     pub min_version_num: Option<String>,
 }
+
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct DependencyId(pub u64);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -75,7 +75,7 @@ pub struct DonationLink {
     pub url: String,
 }
 
-/// A status decides the visbility of a mod in search, URLs, and the whole site itself.
+/// A status decides the visibility of a mod in search, URLs, and the whole site itself.
 /// Approved - Mod is displayed on search, and accessible by URL
 /// Rejected - Mod is not displayed on search, and not accessible by URL (Temporary state, mod can reapply)
 /// Draft - Mod is not displayed on search, and not accessible by URL

--- a/src/routes/mod_creation.rs
+++ b/src/routes/mod_creation.rs
@@ -588,7 +588,7 @@ async fn create_initial_version(
     let dependencies = version_data
         .dependencies
         .iter()
-        .map(|x| ((x.version_id).into(), x.dependency_type.to_string()))
+        .map(|x| (crate::database::models::ModId::from(x.mod_id), x.dependency_type.to_string()))
         .collect::<Vec<_>>();
 
     let version = models::version_item::VersionBuilder {

--- a/src/routes/mod_creation.rs
+++ b/src/routes/mod_creation.rs
@@ -517,6 +517,7 @@ async fn mod_create_inner(
             is_nsfw: mod_create_data.is_nsfw,
             slug: mod_create_data.mod_slug.unwrap(),
             donation_urls,
+            dependencies: None
         };
 
         let now = chrono::Utc::now();
@@ -547,6 +548,7 @@ async fn mod_create_inner(
             wiki_url: mod_builder.wiki_url.clone(),
             discord_url: mod_builder.discord_url.clone(),
             donation_urls: mod_create_data.donation_urls.clone(),
+            dependencies: mod_builder.dependencies.clone(),
         };
 
         let _mod_id = mod_builder.insert(&mut *transaction).await?;

--- a/src/routes/mods.rs
+++ b/src/routes/mods.rs
@@ -2,7 +2,7 @@ use crate::auth::get_user_from_headers;
 use crate::database;
 use crate::file_hosting::FileHost;
 use crate::models;
-use crate::models::mods::{DonationLink, ModId, ModStatus, SearchRequest};
+use crate::models::mods::{DonationLink, ModId, ModStatus, SearchRequest, Dependency, DependencyType};
 use crate::models::teams::Permissions;
 use crate::routes::ApiError;
 use crate::search::indexing::queue::CreationQueue;
@@ -356,6 +356,19 @@ pub fn convert_mod(data: database::models::mod_item::QueryMod) -> models::mods::
                 })
                 .collect(),
         ),
+        dependencies: if data.dependencies.is_empty() {
+            None
+        } else {
+            // Probably find a more precise way to create the Dependency objects
+            Some(
+                data.dependencies.iter().map(
+                    |dep_id| Dependency {
+                        mod_id: ModId(dep_id.as_str().parse::<u64>().unwrap_or_default()), // add better error checking?
+                        dependency_type: DependencyType::Required,
+                        min_version_num: None
+                    }).collect()
+            )
+        },
     }
 }
 

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -198,7 +198,7 @@ async fn version_create_inner(
             let dependencies = version_create_data
                 .dependencies
                 .iter()
-                .map(|x| ((x.version_id).into(), x.dependency_type.to_string()))
+                .map(|x| ((x.mod_id).into(), x.dependency_type.to_string()))
                 .collect::<Vec<_>>();
 
             version_builder = Some(VersionBuilder {

--- a/src/routes/versions.rs
+++ b/src/routes/versions.rs
@@ -157,8 +157,9 @@ fn convert_version(data: database::models::version_item::QueryVersion) -> models
             .dependencies
             .into_iter()
             .map(|d| Dependency {
-                version_id: d.0.into(),
+                mod_id: d.0.into(),
                 dependency_type: DependencyType::from_str(&*d.1),
+                min_version_num: d.2,
             })
             .collect(),
     }
@@ -300,8 +301,8 @@ pub async fn version_edit(
                 .map_err(|e| ApiError::DatabaseError(e.into()))?;
 
                 for dependency in dependencies {
-                    let dependency_id: database::models::ids::VersionId =
-                        dependency.version_id.clone().into();
+                    let dependency_id: database::models::ids::ModId =
+                        dependency.mod_id.clone().into();
 
                     sqlx::query!(
                         "
@@ -309,7 +310,7 @@ pub async fn version_edit(
                         VALUES ($1, $2, $3)
                         ",
                         id as database::models::ids::VersionId,
-                        dependency_id as database::models::ids::VersionId,
+                        dependency_id as database::models::ids::ModId,
                         dependency.dependency_type.as_str()
                     )
                     .execute(&mut *transaction)


### PR DESCRIPTION
Changed the Dependency struct in src/models/mods.rs to reflect the new spec proposed, where each Dependency has a Mod ID for the mod that is being depended on, a dependency type, and an optional minimum version number.

Each Mod should have its own array of Dependency objects, as we discussed.

The database will need to be updated to accommodate the new `minimum version number` field, as well as the queries that are being sent. I modified the parsing on some of the queries to get it to compile, but they might not be correct.